### PR TITLE
Show/hide Buttons and Disabled CheckAnswersButton

### DIFF
--- a/src/Actions/clearUserAnswerActions.js
+++ b/src/Actions/clearUserAnswerActions.js
@@ -1,0 +1,9 @@
+export const CLEARANSWER = 'clearUserAnswer';
+export function clearUserAnswer(){
+	return {
+		type:"CLEARANSWER",
+		payload: {
+			userAnswer: ""	//returns a blank object. This should reset the state. This is used to disable the CheckAnswerButton component.
+		}
+	}
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { StyleSheet, css } from 'aphrodite';
+import {connect} from 'react-redux';
 
 import Nav from './Components/Nav.js';
 import Question from './Components/Question.js';
@@ -21,17 +22,21 @@ const styles = StyleSheet.create({
   }
 	
 });
+/*this.props.currentPassFail.passFail is true*/
+//console.log(this.props.currentPassFail.passFail);
 
 class App extends Component {	
+//console.log(this.props.currentPassFail.passFail);	
   render() {
+console.log(this.props.currentPassFail.passFail);	  
     return (
       <div className="container-fliud">
 		<div className= {`col-xs-12 col-sm-8 col-sm-offset-2 col-md-4 col-md-offset-4 col-lg-4 col-lg-offset-4 col-xl-6 col-xl-offset-3 ${css(styles.appBackground)}`}>
 		  <Nav />
 		  <Question />
 		  <MCAnswersList />
-		  <CheckAnswerButton />
-		  <DoneButton />
+		  {!this.props.currentPassFail.passFail && <CheckAnswerButton />}
+		  {this.props.currentPassFail.passFail && <DoneButton />}
 		  <Motivation />
 		</div>
       </div>
@@ -39,4 +44,9 @@ class App extends Component {
   }
 }
 
-export default App;
+//map imported state of the showPassFail to show/hide the CheckAnswerButton and DoneButton components.
+const mapStateToProps = state => ({
+	currentPassFail: state.passFail
+});
+
+export default connect(mapStateToProps)(App);

--- a/src/App.js
+++ b/src/App.js
@@ -22,13 +22,10 @@ const styles = StyleSheet.create({
   }
 	
 });
-/*this.props.currentPassFail.passFail is true*/
-//console.log(this.props.currentPassFail.passFail);
 
+/**/
 class App extends Component {	
-//console.log(this.props.currentPassFail.passFail);	
-  render() {
-console.log(this.props.currentPassFail.passFail);	  
+  render() {	  
     return (
       <div className="container-fliud">
 		<div className= {`col-xs-12 col-sm-8 col-sm-offset-2 col-md-4 col-md-offset-4 col-lg-4 col-lg-offset-4 col-xl-6 col-xl-offset-3 ${css(styles.appBackground)}`}>

--- a/src/Components/CheckAnswerButton.js
+++ b/src/Components/CheckAnswerButton.js
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
   }
 });
 
-//Primary button used by the user to check if the selected answer is correct. When pressed the answer is saved to state and the correct/incorrect answers is shown using CSS. This button then is hidden and the Done button is shown. 
+//Primary button used by the user to check if the selected answer is correct. When pressed the answer is saved to state and the correct/incorrect answers is shown using CSS. This button then is hidden and the Done button is shown. The button is disabled if an answer is not selected. 
 class CheckAnswerButton extends Component{
 	
   //method to change the passFail attribute of each test's object to pass or fail. This will be use to change the CSS to green for correct and red for incorrect. 	
@@ -57,16 +57,11 @@ class CheckAnswerButton extends Component{
     return(
       <div className={`row ${css(styles.whiteSpaceAboveElement)}`}>
         <div className="col-xs-12 col-sm-12 col-md-12 col-lg-12 text-center">
-          <Button className={css(styles.buttonTextColor)} bsStyle="success" onClick={this.onCheckAnswer}>Check Answer</Button>
+          <Button className={css(styles.buttonTextColor)} bsStyle="success" onClick={this.onCheckAnswer} disabled={this.props.currentAnswer.userAnswer===""}>Check Answer</Button>
         </div>
       </div>
    );      //end of return
  }//end of render
-
-/*      To Do
-- add attribute to disable={} if player hasn't chosen an answer
-*/  
-
 }//end of CheckAnswerButton Class
 
 /*Use Redux to get the current number of questions answered, current count of correct answers, and the current array of questions and answers*/

--- a/src/Components/DoneButton.js
+++ b/src/Components/DoneButton.js
@@ -34,18 +34,18 @@ class DoneButton extends Component{
 	this.props.onUpdateScore(newScore);  
   }
 	
-  //Method 	
+  //Method to send Redux actions to move the user to the next question, disable the CheckAnswersButton, and update the score. 
   getNextQuestion = event => {
 	  
 	  this.props.onAddQuestionsAnswered();// add one to the count of answered questions
-	  
-	  this.props.onHidePassAnswers();//send an Redux action to return false to the Redux store, thus hiding the CSS (green/correct and red/incorrect) of the displayed answers (color is now black)
-	  
-	  this.props.onClearUserAnswer();
 
 	  //Update the score by dividing questionAnswer/count (the current amount of questions answer by the count of correct answers given, then waiting 5 seconds before updating score. The timeout give the async Redux actions time to update. If not use, the first variable, count, updates before the second variable and return a NAN. 
 	  setTimeout(() =>{
-	    this.getScore(), 5000
+	    this.getScore(), 5000		  
+	  
+	    this.props.onHidePassAnswers();//send an Redux action to return false to the Redux store, thus hiding the CSS (green/correct and red/incorrect) of the displayed answers (color is now black)
+	  
+	    this.props.onClearUserAnswer(); //send an Redux action to reset the user answer Redux state. This will disable the CheckAnswerButton component. 		  
 	  });	
 
   }		

--- a/src/Components/DoneButton.js
+++ b/src/Components/DoneButton.js
@@ -11,6 +11,8 @@ import {updateScore} from '../Actions/scoreActions.js';
 
 //Redux action to update the showPassFail state to false
 import {showCSSFail} from '../Actions/hidePassFailActions.js';
+
+import {clearUserAnswer} from '../Actions/clearUserAnswerActions.js';//import action to reset the userAnswer state
  
 const styles = StyleSheet.create({
   whiteSpaceAboveElement:{
@@ -38,6 +40,8 @@ class DoneButton extends Component{
 	  this.props.onAddQuestionsAnswered();// add one to the count of answered questions
 	  
 	  this.props.onHidePassAnswers();//send an Redux action to return false to the Redux store, thus hiding the CSS (green/correct and red/incorrect) of the displayed answers (color is now black)
+	  
+	  this.props.onClearUserAnswer();
 
 	  //Update the score by dividing questionAnswer/count (the current amount of questions answer by the count of correct answers given, then waiting 5 seconds before updating score. The timeout give the async Redux actions time to update. If not use, the first variable, count, updates before the second variable and return a NAN. 
 	  setTimeout(() =>{
@@ -64,11 +68,12 @@ const mapStateToProps = state =>({
 	questionsAnswered: state.answered
 });
 
-//map the imported Redux actions to a local method to be used by the component. This will allow the components to change the state of the Redux store such as questions answer, current score, and current value of showPass.
+//map the imported Redux actions to a local method to be used by the component. This will allow the components to change the state of the Redux store such as questions answer, current score, user selected answer, and current value of showPass.
 const mapActionsToProps = {
   onAddQuestionsAnswered: addQuestionsAnswered,
   onUpdateScore: updateScore,
-  onHidePassAnswers: showCSSFail
+  onHidePassAnswers: showCSSFail,
+  onClearUserAnswer: clearUserAnswer
 };
 
 export default connect(mapStateToProps,mapActionsToProps)(DoneButton);

--- a/src/Reducers/userAnswer.js
+++ b/src/Reducers/userAnswer.js
@@ -3,6 +3,8 @@ export default function currentUserAnswer(state={"userAnswer": ""}, {type, paylo
 	switch(type){
 		case 'USERANSWER':
 			return payload;//When a user chosen a new answer, the state is updated with it.
+		case 'CLEARANSWER':
+			return payload;//When a user press the DoneButton, the state is reset to "". This is use to disable the CheckAnswerButton component.
 		default:
 			return state;
 	}


### PR DESCRIPTION
- Used the showPassFail state to show/hide the CheckAnswerButton and DoneButton. This way only button is shown at a time. 
- Created a new action to reset the userAnswer state. Then  disable the CheckAnswerButton if the userAnswer state is blank (been reset). 
- This created a bug in the DoneButton componet getNextQuestion() in which the score became incorrect. The fix was to move all Redux actions except the addQuestionAnswered to the setTimeout(). 